### PR TITLE
Skip plugins whose GitHub repo is not found (404)

### DIFF
--- a/bin/fetch-download-stats.sh
+++ b/bin/fetch-download-stats.sh
@@ -175,10 +175,42 @@ curl_github() {
   : > "${tmpfile}"
 }
 
+# Exit status returned by get_download_count when the repository (or its
+# releases) cannot be found on GitHub, i.e. the API responded with HTTP 404.
+readonly EXIT_CODE_REPO_NOT_FOUND=44
+
+# Writes the total number of release-asset downloads for the given GitHub repo
+# to stdout.
+#
+# Returns:
+#   0                          on success
+#   EXIT_CODE_REPO_NOT_FOUND   when the repo is not found on GitHub (HTTP 404)
+# Any other HTTP status is treated as an unexpected error and aborts the script.
 get_download_count() {
   local github_org_slash_repo="$1"
 
-  curl_github "/repos/${github_org_slash_repo}/releases" | jq -c '[.[].assets[].download_count] | add // 0'
+  # Append the HTTP status code to the response body via -w so we can branch on
+  # it. Even though -f makes curl exit non-zero on an error response, -w still
+  # emits the status code, so we rely on it rather than on curl's exit status.
+  local output=''
+  output="$(curl_github -w $'\n%{http_code}' "/repos/${github_org_slash_repo}/releases")" || true
+
+  # Split the trailing status code off the (possibly multi-line) body.
+  local http_status="${output##*$'\n'}"
+  # Stash the body in the shared temp file for jq to consume.
+  printf '%s' "${output%$'\n'*}" > "${tmpfile}"
+
+  case "${http_status}" in
+    200)
+      jq -c '[.[].assets[].download_count] | add // 0' < "${tmpfile}"
+      ;;
+    404)
+      return "${EXIT_CODE_REPO_NOT_FOUND}"
+      ;;
+    *)
+      error_and_exit "unexpected HTTP status ${http_status:-<none>} while fetching releases for ${github_org_slash_repo}"
+      ;;
+  esac
 }
 
 main() {
@@ -200,7 +232,14 @@ main() {
       continue
     fi
 
-    download_count="$(get_download_count "${github_org_slash_repo}")"
+    local fetch_status=0
+    download_count="$(get_download_count "${github_org_slash_repo}")" || fetch_status=$?
+    if [[ "${fetch_status}" -eq "${EXIT_CODE_REPO_NOT_FOUND}" ]]; then
+      warn "repository ${github_org_slash_repo} for plugin ${plugin_name} not found on GitHub (HTTP 404), skipping"
+      continue
+    elif [[ "${fetch_status}" -ne 0 ]]; then
+      error_and_exit "failed to fetch download count for plugin ${plugin_name} (${github_org_slash_repo})"
+    fi
     info "${plugin_name} = ${download_count} downloads"
 
     local plugin_stats_json='{}'


### PR DESCRIPTION
The fetch-download-stats job (run #584) failed because the plugin
"why-pending" points to a GitHub repo that no longer exists. The
releases API returned 404, curl -fsSL produced no output, the empty
download count broke the downstream jq, and the whole run aborted.

PR #535 worked around such cases with a hardcoded blocklist, but that
does not scale as more upstream repos get deleted or renamed.

Instead, detect a 404 per plugin and skip it automatically:
- get_download_count now captures the HTTP status via -w '%{http_code}'
  (which curl still prints even when -f makes it exit non-zero) and
  returns a dedicated EXIT_CODE_REPO_NOT_FOUND on 404.
- main skips the plugin with a warning on 404, and still aborts loudly
  on any other unexpected HTTP status so data isn't silently dropped.

The existing blocklist is retained for intentional exclusions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Sv1cgCnyYmqAyySMPq4Fd3